### PR TITLE
feat: joint `upload_and_add_file_to_graph` method for graph resources

### DIFF
--- a/src/writerai/resources/graphs.py
+++ b/src/writerai/resources/graphs.py
@@ -12,7 +12,7 @@ from ..types import (
     graph_update_params,
     graph_add_file_to_graph_params,
 )
-from .._types import NOT_GIVEN, Body, FileTypes, Query, Headers, NotGiven
+from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven, FileTypes
 from .._utils import (
     maybe_transform,
     async_maybe_transform,

--- a/src/writerai/resources/graphs.py
+++ b/src/writerai/resources/graphs.py
@@ -12,7 +12,7 @@ from ..types import (
     graph_update_params,
     graph_add_file_to_graph_params,
 )
-from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
+from .._types import NOT_GIVEN, Body, FileTypes, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
     async_maybe_transform,
@@ -296,6 +296,40 @@ class GraphsResource(SyncAPIResource):
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
             cast_to=File,
+        )
+
+    def upload_and_add_file_to_graph(
+        self,
+        graph_id: str,
+        *,
+        content: FileTypes,
+        content_disposition: str,
+        content_type: str,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> File:
+        if not graph_id:
+            raise ValueError(f"Expected a non-empty value for `graph_id` but received {graph_id!r}")
+        uploaded_file = self._client.files.upload(
+            content=content,
+            content_disposition=content_disposition,
+            content_type=content_type,
+            extra_body=extra_body,
+            extra_query=extra_query,
+            extra_headers=extra_headers,
+            timeout=timeout
+        )
+        return self.add_file_to_graph(
+            graph_id=graph_id,
+            file_id=uploaded_file.id,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            timeout=timeout
         )
 
     def remove_file_from_graph(
@@ -598,6 +632,40 @@ class AsyncGraphsResource(AsyncAPIResource):
             cast_to=File,
         )
 
+    async def upload_and_add_file_to_graph(
+        self,
+        graph_id: str,
+        *,
+        content: FileTypes,
+        content_disposition: str,
+        content_type: str,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> File:
+        if not graph_id:
+            raise ValueError(f"Expected a non-empty value for `graph_id` but received {graph_id!r}")
+        uploaded_file = await self._client.files.upload(
+            content=content,
+            content_disposition=content_disposition,
+            content_type=content_type,
+            extra_body=extra_body,
+            extra_query=extra_query,
+            extra_headers=extra_headers,
+            timeout=timeout
+        )
+        return await self.add_file_to_graph(
+            graph_id=graph_id,
+            file_id=uploaded_file.id,
+            extra_body=extra_body,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            timeout=timeout
+        )
+
     async def remove_file_from_graph(
         self,
         file_id: str,
@@ -657,6 +725,9 @@ class GraphsResourceWithRawResponse:
         self.add_file_to_graph = to_raw_response_wrapper(
             graphs.add_file_to_graph,
         )
+        self.upload_and_add_file_to_graph = to_raw_response_wrapper(
+            graphs.upload_and_add_file_to_graph,
+        )
         self.remove_file_from_graph = to_raw_response_wrapper(
             graphs.remove_file_from_graph,
         )
@@ -683,6 +754,9 @@ class AsyncGraphsResourceWithRawResponse:
         )
         self.add_file_to_graph = async_to_raw_response_wrapper(
             graphs.add_file_to_graph,
+        )
+        self.upload_and_add_file_to_graph = async_to_raw_response_wrapper(
+            graphs.upload_and_add_file_to_graph,
         )
         self.remove_file_from_graph = async_to_raw_response_wrapper(
             graphs.remove_file_from_graph,
@@ -711,6 +785,9 @@ class GraphsResourceWithStreamingResponse:
         self.add_file_to_graph = to_streamed_response_wrapper(
             graphs.add_file_to_graph,
         )
+        self.upload_and_add_file_to_graph = to_streamed_response_wrapper(
+            graphs.upload_and_add_file_to_graph,
+        )
         self.remove_file_from_graph = to_streamed_response_wrapper(
             graphs.remove_file_from_graph,
         )
@@ -737,6 +814,9 @@ class AsyncGraphsResourceWithStreamingResponse:
         )
         self.add_file_to_graph = async_to_streamed_response_wrapper(
             graphs.add_file_to_graph,
+        )
+        self.upload_and_add_file_to_graph = async_to_streamed_response_wrapper(
+            graphs.upload_and_add_file_to_graph,
         )
         self.remove_file_from_graph = async_to_streamed_response_wrapper(
             graphs.remove_file_from_graph,


### PR DESCRIPTION
Adds a `upload_and_add_file_to_graph` method to Graph resource, which allows to use single call for uploading and adding the file to graph.